### PR TITLE
Fix rare ArrayIndexOutOfBoundsException

### DIFF
--- a/plugin/src/main/java/me/badbones69/crazyenchantments/api/CrazyEnchantments.java
+++ b/plugin/src/main/java/me/badbones69/crazyenchantments/api/CrazyEnchantments.java
@@ -564,7 +564,8 @@ public class CrazyEnchantments {
             if (enchantment.isActivated() && itemLore != null) {
                 for (String lore : itemLore) {
                     String[] split = lore.split(" ");
-                    if (lore.replace(" " + split[split.length - 1], "").equals(enchantment.getColor() + enchantment.getCustomName())) {
+                    // split can generate a empty array in rare case
+                    if (split.length > 0 && lore.replace(" " + split[split.length - 1], "").equals(enchantment.getColor() + enchantment.getCustomName())) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Server version: 1.17.1
Java: 16

Plugin throws an error because the split returns an empty array (which shouldn't happen, but it does)
> Could not pass event PlayerInteractEvent to CrazyEnchantments v1.8-Dev-Build-v10-Build#175
java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 0
        at me.badbones69.crazyenchantments.api.CrazyEnchantments.hasEnchantment(CrazyEnchantments.java:567) ~[CrazyEnchantments[v1.8-Dev-Build-v10] (2).jar:?]